### PR TITLE
Impl /v1/job_executions/:message_id in barbeque:runner

### DIFF
--- a/lib/barbeque_client/runner.rb
+++ b/lib/barbeque_client/runner.rb
@@ -7,28 +7,63 @@ module BarbequeClient
   class Runner < Sinatra::Base
     set :port, ENV['PORT'] || 3003
 
+    class << self
+      # global variable
+      def messages
+        @messages ||= {}
+      end
+    end
+
     post '/v1/job_executions' do
       params = JSON.parse(request.body.read)
-      spawn(
+      message_id = SecureRandom.uuid
+      pid = spawn(
         'bundle', 'exec', 'rake', 'barbeque:execute',
+        "BARBEQUE_MESSAGE_ID=#{message_id}",
         "BARBEQUE_JOB=#{params['job']}", "BARBEQUE_MESSAGE=#{params['message']}",
         "BARBEQUE_RETRY_COUNT=0",
+        in: :close
       )
+      Runner.messages[message_id] = Process.detach(pid)
 
       content_type :json
-      { status: 'pending', message_id: SecureRandom.uuid }.to_json
+      { status: 'pending', message_id: message_id }.to_json
     end
 
     post '/v2/job_executions' do
       params = JSON.parse(request.body.read)
-      spawn(
+      message_id = SecureRandom.uuid
+      pid = spawn(
         'bundle', 'exec', 'rake', 'barbeque:execute',
+        "BARBEQUE_MESSAGE_ID=#{message_id}",
         "BARBEQUE_JOB=#{params['job']}", "BARBEQUE_MESSAGE=#{params['message'].to_json}",
         "BARBEQUE_RETRY_COUNT=0",
+        in: :close
       )
+      Runner.messages[message_id] = Process.detach(pid)
 
       content_type :json
-      { status: 'pending', message_id: SecureRandom.uuid }.to_json
+      { status: 'pending', message_id: message_id }.to_json
+    end
+
+    get '/v1/job_executions/:message_id' do
+      message_id = params['message_id']
+      wait_thr = Runner.messages[message_id]
+
+      status = if wait_thr.nil?
+                 'pending'
+               elsif wait_thr.alive?
+                 'working'
+               else
+                 if wait_thr.value.exitstatus == 0
+                   'success'
+                 else
+                   'failed'
+                 end
+               end
+
+      content_type :json
+      { status: status, message_id: message_id }.to_json
     end
 
     post '/v1/job_executions/:message_id/retries' do


### PR DESCRIPTION
Although `BarbequeClient.#status` uses `/v1/job_executions/:message_id`, rake task `barbeque:runner` did not implement it.

This PR adds naive job status management.