### PR TITLE
Support distributed tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ execution.status     #=> "pending"
 message_id = "a3c653c1-335e-4d4d-a6f9-eb91c0253d02"
 BarbequeClient.status(message_id: message_id) #=> "success"
 ```
+
+### Distributed tracing
+Configure `tracing` option. Pick one of supported tracers.
+See more detail in https://github.com/cookpad/garage_client#tracing.
+
+```
+BarbequeClient.configure do |config|
+  # ...
+  config.tracing = { tracer: 'aws-xray', service: 'barbeque' }
+end
+```

--- a/lib/barbeque_client.rb
+++ b/lib/barbeque_client.rb
@@ -45,6 +45,7 @@ module BarbequeClient
         application:   config.application,
         default_queue: config.default_queue,
         endpoint:      config.endpoint,
+        tracing:       config.tracing,
       )
     end
   end

--- a/lib/barbeque_client/client.rb
+++ b/lib/barbeque_client/client.rb
@@ -3,10 +3,11 @@ require 'json'
 
 module BarbequeClient
   class Client
-    def initialize(application:, default_queue:, endpoint:)
+    def initialize(application:, default_queue:, endpoint:, tracing: {})
       @application   = application
       @default_queue = default_queue
       @endpoint      = endpoint
+      @tracing       = tracing
     end
 
     # @param [String] job     - Job name to enqueue.
@@ -50,10 +51,13 @@ module BarbequeClient
     private
 
     def garage_client
-      @garage_client ||= GarageClient::Client.new(
-        endpoint: @endpoint,
-        path_prefix: '/',
-      )
+      @garage_client ||= GarageClient::Client.new(garage_client_option)
+    end
+
+    def garage_client_option
+      option = { endpoint: @endpoint, path_prefix: '/' }
+      option[:tracing] = @tracing if @tracing[:tracer]
+      option
     end
   end
 end

--- a/lib/barbeque_client/configuration.rb
+++ b/lib/barbeque_client/configuration.rb
@@ -8,6 +8,7 @@ module BarbequeClient
       application
       default_queue
       endpoint
+      tracing
     ]
   end
 end


### PR DESCRIPTION
Now garage_client supports distributed tracing by adding tracing configuration: https://github.com/cookpad/garage_client/pull/22

To use that tracing feature, we need to add same configuration interface on this library.

@cookpad/dev-infra Please take a look at this?