### PR TITLE
Support non-Array messages for BarbequeClient::Executor

### DIFF
--- a/lib/barbeque_client/executor.rb
+++ b/lib/barbeque_client/executor.rb
@@ -12,6 +12,10 @@ module BarbequeClient
       @queue_name = queue_name
 
       parsed_message = JSON.load(message)
+
+      # `arguments` in ActiveJob::Base.execute is expected as Array
+      # and it expands to the arguments for AJ::Base#perform.
+      # So when message is not an Array, it's converted to a 1-element Array.
       if parsed_message.is_a?(Array)
         @message = parsed_message
       else

--- a/lib/barbeque_client/executor.rb
+++ b/lib/barbeque_client/executor.rb
@@ -8,9 +8,15 @@ module BarbequeClient
     # @param [String] queue_name - barbeque's job_queues.name
     def initialize(job:, message:, message_id:, queue_name:)
       @job        = job
-      @message    = JSON.load(message)
       @message_id = message_id
       @queue_name = queue_name
+
+      parsed_message = JSON.load(message)
+      if parsed_message.is_a?(Array)
+        @message = parsed_message
+      else
+        @message = [parsed_message]
+      end
     end
 
     def run

--- a/lib/barbeque_client/executor.rb
+++ b/lib/barbeque_client/executor.rb
@@ -16,11 +16,7 @@ module BarbequeClient
       # `arguments` in ActiveJob::Base.execute is expected as Array
       # and it expands to the arguments for AJ::Base#perform.
       # So when message is not an Array, it's converted to a 1-element Array.
-      if parsed_message.is_a?(Array)
-        @message = parsed_message
-      else
-        @message = [parsed_message]
-      end
+      @message = Array.wrap(parsed_message)
     end
 
     def run

--- a/spec/barbeque/executor_spec.rb
+++ b/spec/barbeque/executor_spec.rb
@@ -26,7 +26,7 @@ describe BarbequeClient::Executor do
       expect(test_job.queue_name).to eq(queue_name)
     end
 
-    context 'with non-Array args' do
+    context 'with non-Array args like Notification message' do
       let(:args) { { 'foo' => 'bar' } }
       it 'performs a job' do
         expect(test_job).to receive(:perform).with('foo' => 'bar')

--- a/spec/barbeque/executor_spec.rb
+++ b/spec/barbeque/executor_spec.rb
@@ -19,11 +19,22 @@ describe BarbequeClient::Executor do
     end
 
     it 'performs a job' do
-      expect(test_job).to receive(:perform).with(*args)
+      expect(test_job).to receive(:perform).with('foo', 'bar')
       executor.run
 
       expect(test_job.job_id).to eq(message_id)
       expect(test_job.queue_name).to eq(queue_name)
+    end
+
+    context 'with non-Array args' do
+      let(:args) { { 'foo' => 'bar' } }
+      it 'performs a job' do
+        expect(test_job).to receive(:perform).with('foo' => 'bar')
+        executor.run
+
+        expect(test_job.job_id).to eq(message_id)
+        expect(test_job.queue_name).to eq(queue_name)
+      end
     end
   end
 end

--- a/spec/barbeque/executor_spec.rb
+++ b/spec/barbeque/executor_spec.rb
@@ -19,7 +19,7 @@ describe BarbequeClient::Executor do
     end
 
     it 'performs a job' do
-      expect(test_job).to receive(:perform).with('foo', 'bar')
+      expect(test_job).to receive(:perform).with(*args)
       executor.run
 
       expect(test_job.job_id).to eq(message_id)


### PR DESCRIPTION
ActiveJob expects only Array for its argments. Therefore if other class'
instance cames, it crashes or works with unintended behavior. Especially
Hash (e.g. `{ "foo" => "bar" }`) cames, Job's #perform method receives
a key-value pair Array (e.g. `["foo", "bar"]`) as an argument. It's
unexpected and not useful for most cases. So with this patch if the
argument is not Array, it's transformed into one element Array with the
original argument (`{ "foo" => "bar" }` to `[{ "foo" => "bar" }]`.

@cookpad/dev-infra @k0kubun How do you think about it?