### PR TITLE
`tracing` can be passed as nil value

### DIFF
--- a/lib/barbeque_client/client.rb
+++ b/lib/barbeque_client/client.rb
@@ -7,7 +7,7 @@ module BarbequeClient
       @application   = application
       @default_queue = default_queue
       @endpoint      = endpoint
-      @tracing       = tracing
+      @tracing       = tracing || {}
     end
 
     # @param [String] job     - Job name to enqueue.


### PR DESCRIPTION
Because `Configuration` initializes `tracing` with nil.

---

This is follow-up PR for https://github.com/cookpad/barbeque_client/pull/5.

@cookpad/dev-infra @yoshiori FYI