### PR TITLE
Give correct error message for enqueue_at

### DIFF
--- a/lib/active_job/queue_adapters/barbeque_adapter.rb
+++ b/lib/active_job/queue_adapters/barbeque_adapter.rb
@@ -7,9 +7,7 @@ module ActiveJob
       end
 
       def enqueue_at(job, timestamp)
-        raise NotImplementedError.new(
-          'Currently setting timestamp is not supported'
-        )
+        BarbequeAdapter.enqueue_at(job, timestamp)
       end
 
       class << self

--- a/lib/active_job/queue_adapters/barbeque_adapter.rb
+++ b/lib/active_job/queue_adapters/barbeque_adapter.rb
@@ -6,6 +6,12 @@ module ActiveJob
         BarbequeAdapter.enqueue(job)
       end
 
+      def enqueue_at(job, timestamp)
+        raise NotImplementedError.new(
+          'Currently setting timestamp is not supported'
+        )
+      end
+
       class << self
         # Interface for ActiveJob 4.2
         def enqueue(job)


### PR DESCRIPTION
Split from #9 

This patch is for:

- Give clear message to rails 5.x user who tries to use `enqueue_at`

before => NameError: 'undefined local variable or method `enqueue_at`'
after => NotImplementedError with 'Currently setting timestamp is not supported'

Could you review this? @cookpad/dev-infra @k0kubun 
