### PR TITLE
Use 'running' instead of 'working' in mock API responses to align with real Barbeque

### DIFF
--- a/lib/barbeque_client/runner.rb
+++ b/lib/barbeque_client/runner.rb
@@ -53,7 +53,7 @@ module BarbequeClient
       status = if wait_thr.nil?
                  'pending'
                elsif wait_thr.alive?
-                 'working'
+                 'running'
                else
                  if wait_thr.value.exitstatus == 0
                    'success'


### PR DESCRIPTION
Barbeque's `/api/v1/barbeque/execution/:message_id` API returns `running` when the execution is in running state, but barbeque_client's mock API returns `working` in the same situation.

Looking in Barbeque's code, I assume that this is a simple error, so this PR fixes it.
https://github.com/cookpad/barbeque/blob/02a77df66fe3045d9230e2b5aeffbbaee9166e9d/app/models/barbeque/job_execution.rb#L14