### PR TITLE
Don't close stdin when spawning executions from Runner

### DIFF
--- a/lib/barbeque_client/runner.rb
+++ b/lib/barbeque_client/runner.rb
@@ -22,7 +22,6 @@ module BarbequeClient
         "BARBEQUE_MESSAGE_ID=#{message_id}",
         "BARBEQUE_JOB=#{params['job']}", "BARBEQUE_MESSAGE=#{params['message']}",
         "BARBEQUE_RETRY_COUNT=0",
-        in: :close
       )
       Runner.messages[message_id] = Process.detach(pid)
 
@@ -38,7 +37,6 @@ module BarbequeClient
         "BARBEQUE_MESSAGE_ID=#{message_id}",
         "BARBEQUE_JOB=#{params['job']}", "BARBEQUE_MESSAGE=#{params['message'].to_json}",
         "BARBEQUE_RETRY_COUNT=0",
-        in: :close
       )
       Runner.messages[message_id] = Process.detach(pid)
 


### PR DESCRIPTION
This patch allows debugging through binding.irb/pry inside spawned jobs.
This is a workaround that works only when jobs are not executed in parallel; if not, console output may be messed up by output from multiple jobs.

@cookpad/infra please review