### PR TITLE
fix spec: Use a hash for a positoinal argument rather than keywords

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
     name: Run test with Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/spec/barbeque/client_spec.rb
+++ b/spec/barbeque/client_spec.rb
@@ -19,11 +19,13 @@ describe BarbequeClient::Client do
       it 'enqueues a job to barbeque' do
         expect(garage_client).to receive(:post).with(
           '/v2/job_executions',
-          application: application,
-          job:         job,
-          message:     message,
-          queue:       default_queue,
-          delay_seconds: nil,
+          {
+            application: application,
+            job:         job,
+            message:     message,
+            queue:       default_queue,
+            delay_seconds: nil,
+          },
         ).and_return(result)
         client.create_execution(job: job, message: message)
       end
@@ -34,11 +36,13 @@ describe BarbequeClient::Client do
         it 'enqueues with specified parameters' do
           expect(garage_client).to receive(:post).with(
             '/v2/job_executions',
-            application: application,
-            job:         job,
-            message:     message,
-            queue:       queue,
-            delay_seconds: nil,
+            {
+              application: application,
+              job:         job,
+              message:     message,
+              queue:       queue,
+              delay_seconds: nil,
+            },
           ).and_return(result)
           client.create_execution(job: job, message: message, queue: queue)
         end


### PR DESCRIPTION
With Ruby >= 3.0 and rspec-mocks gem >= 3.10.3, some test cases fail due to improper use of keyword arguments. This patch fixes it and ensures the success of those test cases.

Failure example:

```
1) BarbequeClient::Client#create_execution when barbeque is alive enqueues a job to barbeque
   Failure/Error: result = garage_client.post('/v2/job_executions', params)
     #<InstanceDouble(GarageClient::Client) (anonymous)> received :post with unexpected arguments
       expected: ("/v2/job_executions", {:application=>"cookpad", :delay_seconds=>nil, :job=>"NotifyAuthor", :message=>{:user_id=>1}, :queue=>"main"}) (keyword arguments)
            got: ("/v2/job_executions", {:application=>"cookpad", :delay_seconds=>nil, :job=>"NotifyAuthor", :message=>{:user_id=>1}, :queue=>"main"}) (options hash)
   # ./lib/barbeque_client/client.rb:27:in `create_execution'
   # ./spec/barbeque/client_spec.rb:28:in `block (4 levels) in <top (required)>'
   # ./spec/spec_helper.rb:12:in `block (2 levels) in <top (required)>'
```

References:

https://github.com/cookpad/garage_client/blob/af78afb3505c449d57734dede3b946e708ad31be/lib/garage_client/request.rb#L13
https://github.com/rspec/rspec-mocks/blob/103475e20b0e77df866f9c0574f360337f90aaec/Changelog.md#3103--2022-01-28

@cookpad/infra Would you please review this?