### PR TITLE
Update BarbequeAdapter for Rails 7.2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.6'
-          - '2.7'
-          - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'

--- a/barbeque_client.gemspec
+++ b/barbeque_client.gemspec
@@ -20,9 +20,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'garage_client'
+  spec.add_dependency 'activejob', '>= 7.2'
+  spec.add_dependency 'railties', '>= 7.2'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rails', '~> 6.1.4'
+  spec.add_development_dependency 'rails', '>= 7.2'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec-rails'
 end

--- a/lib/active_job/queue_adapters/barbeque_adapter.rb
+++ b/lib/active_job/queue_adapters/barbeque_adapter.rb
@@ -1,36 +1,24 @@
 module ActiveJob
   module QueueAdapters
-    class BarbequeAdapter
-      # Interface for ActiveJob 5.0
+    class BarbequeAdapter < ActiveJob::QueueAdapters::AbstractAdapter
       def enqueue(job)
-        BarbequeAdapter.enqueue(job)
+        execution = BarbequeClient.enqueue(
+          job:     job.class.to_s,
+          message: ActiveJob::Arguments.serialize(job.arguments),
+          queue:   job.queue_name,
+        )
+        job.job_id = execution.message_id
       end
 
       def enqueue_at(job, timestamp)
-        BarbequeAdapter.enqueue_at(job, timestamp)
-      end
-
-      class << self
-        # Interface for ActiveJob 4.2
-        def enqueue(job)
-          execution = BarbequeClient.enqueue(
-            job:     job.class.to_s,
-            message: ActiveJob::Arguments.serialize(job.arguments),
-            queue:   job.queue_name,
-          )
-          job.job_id = execution.message_id
-        end
-
-        def enqueue_at(job, timestamp)
-          delay_seconds = (timestamp - Time.now.to_f).round
-          execution = BarbequeClient.enqueue(
-            job:     job.class.to_s,
-            message: ActiveJob::Arguments.serialize(job.arguments),
-            queue:   job.queue_name,
-            delay_seconds: delay_seconds,
-          )
-          job.job_id = execution.message_id
-        end
+        delay_seconds = (timestamp - Time.now.to_f).round
+        execution = BarbequeClient.enqueue(
+          job:     job.class.to_s,
+          message: ActiveJob::Arguments.serialize(job.arguments),
+          queue:   job.queue_name,
+          delay_seconds: delay_seconds,
+        )
+        job.job_id = execution.message_id
       end
     end
   end

--- a/lib/barbeque_client/version.rb
+++ b/lib/barbeque_client/version.rb
@@ -1,3 +1,3 @@
 module BarbequeClient
-  VERSION = '0.10.2'
+  VERSION = '0.11.0'
 end


### PR DESCRIPTION
In Rails 7.2, a new class called ActiveJob::QueueAdapter::AbstractAdapter was added. It looks like custom adapters should basically inherit from this class. Considering the support period for Rails, it would be better to stop supporting versions less than Rails 7.2 and make codes simpler.

see also: https://github.com/rails/rails/commit/e922c59207c406d51541622690737783e0ec338e

- Update gemspec to require Rails 7.2 (ActiveJob) and above
- Refactor BarbequeAdapter to inherit from ActiveJob::AbstractAdapter